### PR TITLE
Potential fix for code scanning alert no. 7: Bad HTML filtering regexp

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "swr": "^2.3.3",
     "tailwind-merge": "^3.2.0",
     "uuid": "^11.1.0",
-    "zod": "^3.24.3"
+    "zod": "^3.24.3",
+    "sanitize-html": "^2.16.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/api/process-url/route.ts
+++ b/src/app/api/process-url/route.ts
@@ -80,10 +80,12 @@ export const POST = withApiValidation(
 
       if (generateSummary) {
         // Extract text - this is a simplified approach
-        const textContent = html
-          .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, "")
-          .replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, "")
-          .replace(/<[^>]*>/g, " ")
+        const sanitizeHtml = require("sanitize-html");
+        const sanitizedHtml = sanitizeHtml(html, {
+          allowedTags: [], // Remove all tags
+          allowedAttributes: {}, // Remove all attributes
+        });
+        const textContent = sanitizedHtml
           .replace(/\s+/g, " ")
           .trim()
           .substring(0, 15000); // Limit content


### PR DESCRIPTION
Potential fix for [https://github.com/kudziajaroslaw98/moistus-ai/security/code-scanning/7](https://github.com/kudziajaroslaw98/moistus-ai/security/code-scanning/7)

To fix the issue, we should replace the custom regular expression-based approach with a well-tested HTML sanitization library, such as `sanitize-html`. These libraries are specifically designed to handle edge cases and ensure robust filtering of potentially malicious content. This approach is more reliable and secure than attempting to write custom regex for HTML parsing.

The fix involves:
1. Installing the `sanitize-html` library.
2. Replacing the regex-based script removal logic with a call to `sanitize-html` to strip `<script>` and `<style>` tags safely.
3. Updating the relevant code in `src/app/api/process-url/route.ts`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
