### PR TITLE
fix: add touch long-press context menu fallback for iPad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,10 @@ Format: `[YYYY-MM-DD]` - one entry per day.
   - Why: iPad/iOS WebKit does not reliably emit `contextmenu` for press-and-hold, so mobile users could not access context-menu-only actions
 - **mind-map/mobile-context-menu-trailing-click-guard**: Suppressed the immediate synthetic click/contextmenu events after long-press activation to avoid accidental selection/close side-effects right after opening the menu
   - Why: Long-press interactions can emit trailing click-like events that would immediately interfere with the newly opened custom menu
+- **mind-map/mobile-context-menu-native-race-guard**: Hardened long-press timeout handling against native-contextmenu races by skipping deferred open when the context menu is already open and clearing pending press state when trailing native contextmenu suppression runs
+  - Why: A pointerdown followed by native contextmenu could otherwise allow the long-press timeout to fire later and attempt a duplicate open
+- **mind-map/mobile-context-menu-container-scope**: Scoped touch fallback listeners to the immediate React Flow canvas wrapper instead of the broader ReactFlowArea shell
+  - Why: Gesture suppression should align with the actual flow surface and not capture unrelated modal/shell interactions
 
 ### Added
 
@@ -87,6 +91,8 @@ Format: `[YYYY-MM-DD]` - one entry per day.
   - Why: These state transitions are timing-sensitive and require explicit regression guards
 - **tests/mobile-context-menu-touch-fallback**: Added hook-level long-press regression tests for node/edge/pane targeting, quick-tap and movement cancellation, and trailing-click suppression plus `useContextMenu` coverage for direct `openContextMenuAt` state wiring
   - Why: Touch fallback behavior is timing-sensitive and must remain stable across future React Flow/mobile interaction changes
+- **tests/mobile-context-menu-native-contextmenu-sequence**: Added regression coverage for pointerdown -> native contextmenu -> timeout ordering plus ReactFlowArea hook-wiring assertions for open/closed context-menu state propagation
+  - Why: Prevents regressions in the specific iPad/WebKit race and keeps fallback integration wiring observable in tests
 
 ## [2026-04-07]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Format: `[YYYY-MM-DD]` - one entry per day.
 <!-- Updated: 2026-04-07 - Shipped progressive map-shell streaming and hardened Yjs cleanup idempotency against repeated unsubscribe paths -->
 <!-- Updated: 2026-04-07 - Replaced dashboard spinner fallback with shell-parity loading and in-page progressive map-card skeleton streaming -->
 <!-- Updated: 2026-04-08 - Fixed onboarding skip-state refresh regression and preserved controls-tour paused-step resume across refresh -->
+<!-- Updated: 2026-04-08 - Added touch long-press context menu fallback for iPad/iOS WebKit and regression tests -->
 
 ## [2026-04-08]
 
@@ -75,11 +76,17 @@ Format: `[YYYY-MM-DD]` - one entry per day.
   - Why: Checklist transitions (create-node/pattern updates) intentionally reset active coachmark step and were still able to erase paused controls-tour resume context without a dedicated paused marker
 - **onboarding/manual-resume-anchor-measure-loop**: Disabled target-rect requestAnimationFrame measuring while the manual-resume checklist is intentionally shown on mobile
   - Why: Manual pill expand should be a stable checklist surface for skip/selection actions and does not need continuous anchor measurement until an explicit task CTA restarts guided overlays
+- **mind-map/mobile-context-menu-long-press-fallback**: Added touch long-press detection for `.react-flow__node`, `.react-flow__edge`, and `.react-flow__pane` targets, opening the existing context menu store state at press coordinates and keeping desktop/native `contextmenu` handling unchanged
+  - Why: iPad/iOS WebKit does not reliably emit `contextmenu` for press-and-hold, so mobile users could not access context-menu-only actions
+- **mind-map/mobile-context-menu-trailing-click-guard**: Suppressed the immediate synthetic click/contextmenu events after long-press activation to avoid accidental selection/close side-effects right after opening the menu
+  - Why: Long-press interactions can emit trailing click-like events that would immediately interfere with the newly opened custom menu
 
 ### Added
 
 - **tests/onboarding-resume-regressions**: Added onboarding slice coverage for skip-state hydration races, paused coachmark resume step restore, refresh rehydrate+clamp behavior, mobile `Start`-path resume behavior, checklist minimize/resume regression, and paused controls-step preservation across checklist task updates
   - Why: These state transitions are timing-sensitive and require explicit regression guards
+- **tests/mobile-context-menu-touch-fallback**: Added hook-level long-press regression tests for node/edge/pane targeting, quick-tap and movement cancellation, and trailing-click suppression plus `useContextMenu` coverage for direct `openContextMenuAt` state wiring
+  - Why: Touch fallback behavior is timing-sensitive and must remain stable across future React Flow/mobile interaction changes
 
 ## [2026-04-07]
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@
 <!-- Updated: 2026-04-07 - Documented Strict Mode-safe map unmount cleanup requirement -->
 <!-- Updated: 2026-04-07 - Documented progressive map-shell streaming rules and idempotent Yjs cleanup expectations -->
 <!-- Updated: 2026-04-07 - Documented dashboard shell-parity loading fallback and in-page progressive card skeleton streaming -->
+<!-- Updated: 2026-04-08 - Documented iPad/iOS long-press context-menu fallback contract for React Flow targets -->
 
 ## Engineering Philosophy
 
@@ -176,6 +177,9 @@ pnpm pretty          # Prettier
 
 **Node editor autocomplete surfaces**: Keep `createCompletions()` as the single source of autocomplete options. Desktop uses the native CodeMirror tooltip; mobile hides that tooltip and renders a hybrid presenter: a compact full-width strip attached to the open keyboard, or a caret-anchored floating panel when the keyboard is hidden. Any editor/modal outside-press guard must treat both `[data-node-editor-autocomplete-tray="true"]` and body-portaled `.cm-tooltip*` elements as inside-editor interactions so selecting a suggestion does not dismiss the editor.
 <!-- Updated: 2026-03-28 - Documented the hybrid mobile autocomplete presenter and shared completion engine -->
+
+**Touch context menu fallback**: Do not rely on native `contextmenu` alone for mobile/iPad. Keep `useTouchContextMenuFallback` wired to the React Flow shell so touch long-press on `.react-flow__node[data-id]`, `.react-flow__edge[data-id]`, or `.react-flow__pane` opens the same context-menu store state path (`openContextMenuAt`) used by desktop right-click handlers. Preserve movement cancellation and trailing click/contextmenu suppression to avoid accidental immediate close/select side-effects after long-press activation.
+<!-- Updated: 2026-04-08 - Added iPad/iOS WebKit long-press fallback and post-long-press suppression guardrail -->
 
 **Landing CTA feedback**: Keep landing navigation CTAs (`Start Mapping`, `Get Started`, `Go Pro`) on `StartMappingLink` (`next/link` + `useLinkStatus` + optimistic pending feedback). Keep `src/app/dashboard/loading.tsx` as a dashboard-shell loading fallback (not a blank spinner) while dashboard auth/render work is pending, and keep in-page map-list loading progressive via card skeletons.
 <!-- Updated: 2026-04-07 - Added landing CTA pending-feedback and dashboard loading-boundary guardrail -->

--- a/src/components/mind-map/react-flow-area.test.tsx
+++ b/src/components/mind-map/react-flow-area.test.tsx
@@ -118,8 +118,12 @@ jest.mock('@/hooks/use-context-menu', () => ({
 			onPaneClick: (...args: unknown[]) => mockNoop(...args),
 			onPaneContextMenu: (...args: unknown[]) => mockNoop(...args),
 			onNodeContextMenu: (...args: unknown[]) => mockNoop(...args),
+			openContextMenuAt: (...args: unknown[]) => mockNoop(...args),
 		},
 	}),
+}));
+jest.mock('@/hooks/use-touch-context-menu-fallback', () => ({
+	useTouchContextMenuFallback: () => undefined,
 }));
 jest.mock('@/hooks/use-mobile', () => ({
 	useIsMobile: () => false,

--- a/src/components/mind-map/react-flow-area.test.tsx
+++ b/src/components/mind-map/react-flow-area.test.tsx
@@ -8,6 +8,8 @@ const mockReactFlowRenderHistory: Array<{ nodes: AppNode[]; edges: AppEdge[] }> 
 const mockAnimateGraphToState = jest.fn();
 const mockCancelAnimation = jest.fn();
 const mockNoop = jest.fn();
+const mockOpenContextMenuAt = jest.fn();
+const mockUseTouchContextMenuFallback = jest.fn();
 let mockStoreState: Record<string, unknown>;
 
 jest.mock('@/registry/node-registry', () => ({
@@ -118,12 +120,14 @@ jest.mock('@/hooks/use-context-menu', () => ({
 			onPaneClick: (...args: unknown[]) => mockNoop(...args),
 			onPaneContextMenu: (...args: unknown[]) => mockNoop(...args),
 			onNodeContextMenu: (...args: unknown[]) => mockNoop(...args),
-			openContextMenuAt: (...args: unknown[]) => mockNoop(...args),
+			openContextMenuAt: (...args: unknown[]) =>
+				mockOpenContextMenuAt(...args),
 		},
 	}),
 }));
 jest.mock('@/hooks/use-touch-context-menu-fallback', () => ({
-	useTouchContextMenuFallback: () => undefined,
+	useTouchContextMenuFallback: (...args: unknown[]) =>
+		mockUseTouchContextMenuFallback(...args),
 }));
 jest.mock('@/hooks/use-mobile', () => ({
 	useIsMobile: () => false,
@@ -219,7 +223,12 @@ function createMockStore(overrides: Partial<Record<string, unknown>> = {}) {
 		setReactFlowInstance: mockNoop,
 		setSelectedNodes: mockNoop,
 		setPopoverOpen: mockNoop,
-		popoverOpen: { upgradeUser: false, mapSettings: false, history: false },
+		popoverOpen: {
+			contextMenu: false,
+			upgradeUser: false,
+			mapSettings: false,
+			history: false,
+		},
 		setEdgeInfo: mockNoop,
 		setMapId: mockNoop,
 		addNode: mockNoop,
@@ -272,6 +281,8 @@ describe('ReactFlowArea', () => {
 		mockReactFlowRenderHistory.length = 0;
 		mockAnimateGraphToState.mockReset();
 		mockCancelAnimation.mockReset();
+		mockOpenContextMenuAt.mockReset();
+		mockUseTouchContextMenuFallback.mockReset();
 		mockStoreState = createMockStore();
 		mockAnimateGraphToState.mockImplementation(
 			async ({
@@ -371,5 +382,49 @@ describe('ReactFlowArea', () => {
 
 		expect(nodePositions).toContain(50);
 		expect(edgeWaypointPositions).toContain(100);
+	});
+
+	it('wires touch context menu fallback with expected params and open/closed state', () => {
+		const { rerender } = render(<ReactFlowArea isMapReady={true} />);
+
+		expect(mockUseTouchContextMenuFallback).toHaveBeenCalled();
+		const firstCallParams = mockUseTouchContextMenuFallback.mock.calls[0][0] as {
+			containerRef: { current: unknown };
+			openContextMenuAt: (...args: unknown[]) => unknown;
+			isContextMenuOpen: boolean;
+		};
+		expect(firstCallParams.isContextMenuOpen).toBe(false);
+		expect(typeof firstCallParams.openContextMenuAt).toBe('function');
+		expect(firstCallParams.containerRef).toBeDefined();
+		expect(firstCallParams.containerRef.current).not.toBeNull();
+
+		firstCallParams.openContextMenuAt({
+			x: 10,
+			y: 20,
+			nodeId: 'node-via-hook',
+			edgeId: null,
+		});
+		expect(mockOpenContextMenuAt).toHaveBeenCalledWith({
+			x: 10,
+			y: 20,
+			nodeId: 'node-via-hook',
+			edgeId: null,
+		});
+
+		mockStoreState = createMockStore({
+			popoverOpen: {
+				contextMenu: true,
+				upgradeUser: false,
+				mapSettings: false,
+				history: false,
+			},
+		});
+
+		rerender(<ReactFlowArea isMapReady={true} />);
+
+		const lastCallParams = mockUseTouchContextMenuFallback.mock.calls.at(-1)?.[0] as {
+			isContextMenuOpen: boolean;
+		};
+		expect(lastCallParams.isContextMenuOpen).toBe(true);
 	});
 });

--- a/src/components/mind-map/react-flow-area.tsx
+++ b/src/components/mind-map/react-flow-area.tsx
@@ -740,119 +740,117 @@ export function ReactFlowArea({ isMapReady }: ReactFlowAreaProps) {
 	}, [showUpgradeModal]);
 
 	return (
-		<div
-			className='w-full h-full'
-			key='mind-map-container'
-			ref={touchContextMenuContainerRef}
-		>
-			<ReactFlow
-				colorMode='dark'
-				connectionLineComponent={FloatingConnectionLine}
-				connectionLineType={ConnectionLineType.Bezier}
-				connectionMode={ConnectionMode.Loose}
-				deleteKeyCode={isMapReady && canEdit ? ['Delete'] : null}
-				disableKeyboardA11y={true}
-				edges={renderEdges}
-				edgeTypes={edgeTypes}
-				elementsSelectable={isMapReady && isSelectMode}
-				fitView={true}
-				minZoom={0.1}
-				multiSelectionKeyCode={['Meta', 'Control']}
-				nodes={renderNodes}
-				nodesConnectable={
-					isMapReady && (isSelectMode || activeTool === 'connector') && canEdit
-				}
-				nodesDraggable={
-					isMapReady &&
-					isSelectMode &&
-					canEdit &&
-					!isMobileTapMultiSelectActive
-				}
-				nodeTypes={nodeTypesWithProps}
-				onConnect={onConnect}
-				onConnectEnd={onConnectEnd}
-				onConnectStart={onConnectStart}
-				onEdgeContextMenu={contextMenuHandlers.onEdgeContextMenu}
-				onEdgeDoubleClick={handleEdgeDoubleClick}
-				onEdgesChange={onEdgesChange}
-				onEdgesDelete={handleEdgesDelete}
-				onNodeClick={handleNodeClick}
-				onNodeDoubleClick={handleNodeDoubleClick}
-				onNodeContextMenu={contextMenuHandlers.onNodeContextMenu}
-				onNodeDragStart={handleNodeDragStart}
-				onNodeDragStop={handleNodeDragStop}
-				onNodesChange={onNodesChange}
-				onNodesDelete={handleNodesDelete}
-				onPaneClick={contextMenuHandlers.onPaneClick}
-				onPaneContextMenu={contextMenuHandlers.onPaneContextMenu}
-				onSelectionContextMenu={(event) =>
-					contextMenuHandlers.onPaneContextMenu(event)
-				}
-				onSelectionChange={handleSelectionChange}
-				panOnDrag={true}
-				selectionMode={SelectionMode.Partial}
-				snapGrid={[GRID_SIZE, GRID_SIZE]}
-				snapToGrid={true}
-				className={cn([
-					isPanningMode && 'cursor-grab',
-					(activeTool === 'node' || activeTool === 'text') &&
-						'cursor-crosshair',
-				])}
-				style={
-					{
-						'--xy-background-color-default': 'var(--color-base)',
-					} as CSSProperties
-				}
-			>
-				<Background
-					color='rgba(255, 255, 255, 0.3)'
-					gap={GRID_SIZE}
-					variant={BackgroundVariant.Dots}
-				/>
-
-				<MindMapTopBar
-					mapId={mapId as string}
-					mindMap={mindMap}
-					isMapReady={isMapReady}
-					currentUser={currentUser}
-					userProfile={userProfile}
-					activityState={activityState}
-					popoverOpen={popoverOpen}
-					canEdit={canEdit}
-					mobileUnreadCount={mobileNotifications.visibleUnreadCount}
-					handleToggleHistorySidebar={handleToggleHistorySidebar}
-					handleToggleMapSettings={handleToggleMapSettings}
-					handleToggleSharePanel={handleToggleSharePanel}
-					handleOpenSettings={handleOpenSettings}
-					mobileMenuOpen={mobileMenuOpen}
-					setMobileMenuOpen={setMobileMenuOpen}
-				/>
-
-				<Panel position='bottom-center'>
-					<div
-						ref={bottomDockRef}
-						className='flex flex-col gap-2 items-center'
-						data-testid='bottom-dock'
-					>
-						<ModeIndicator />
-
-						<Toolbar
-							isMapReady={isMapReady}
-							mobileTapMultiSelectEnabled={mobileTapMultiSelectEnabled}
-							onMobileTapMultiSelectChange={setMobileTapMultiSelectEnabled}
-						/>
-					</div>
-				</Panel>
-
-				<Panel className='m-4 pt-10' position='top-right'></Panel>
-
-				<Panel position='top-left'>
-					<RealtimeCursors
-						reactFlowInstance={reactFlowInstance}
-						roomName={getMindMapRoomName(mapId as string, 'cursor')}
+		<div className='w-full h-full' key='mind-map-container'>
+			<div className='w-full h-full' ref={touchContextMenuContainerRef}>
+				<ReactFlow
+					colorMode='dark'
+					connectionLineComponent={FloatingConnectionLine}
+					connectionLineType={ConnectionLineType.Bezier}
+					connectionMode={ConnectionMode.Loose}
+					deleteKeyCode={isMapReady && canEdit ? ['Delete'] : null}
+					disableKeyboardA11y={true}
+					edges={renderEdges}
+					edgeTypes={edgeTypes}
+					elementsSelectable={isMapReady && isSelectMode}
+					fitView={true}
+					minZoom={0.1}
+					multiSelectionKeyCode={['Meta', 'Control']}
+					nodes={renderNodes}
+					nodesConnectable={
+						isMapReady && (isSelectMode || activeTool === 'connector') && canEdit
+					}
+					nodesDraggable={
+						isMapReady &&
+						isSelectMode &&
+						canEdit &&
+						!isMobileTapMultiSelectActive
+					}
+					nodeTypes={nodeTypesWithProps}
+					onConnect={onConnect}
+					onConnectEnd={onConnectEnd}
+					onConnectStart={onConnectStart}
+					onEdgeContextMenu={contextMenuHandlers.onEdgeContextMenu}
+					onEdgeDoubleClick={handleEdgeDoubleClick}
+					onEdgesChange={onEdgesChange}
+					onEdgesDelete={handleEdgesDelete}
+					onNodeClick={handleNodeClick}
+					onNodeDoubleClick={handleNodeDoubleClick}
+					onNodeContextMenu={contextMenuHandlers.onNodeContextMenu}
+					onNodeDragStart={handleNodeDragStart}
+					onNodeDragStop={handleNodeDragStop}
+					onNodesChange={onNodesChange}
+					onNodesDelete={handleNodesDelete}
+					onPaneClick={contextMenuHandlers.onPaneClick}
+					onPaneContextMenu={contextMenuHandlers.onPaneContextMenu}
+					onSelectionContextMenu={(event) =>
+						contextMenuHandlers.onPaneContextMenu(event)
+					}
+					onSelectionChange={handleSelectionChange}
+					panOnDrag={true}
+					selectionMode={SelectionMode.Partial}
+					snapGrid={[GRID_SIZE, GRID_SIZE]}
+					snapToGrid={true}
+					className={cn([
+						isPanningMode && 'cursor-grab',
+						(activeTool === 'node' || activeTool === 'text') &&
+							'cursor-crosshair',
+					])}
+					style={
+						{
+							'--xy-background-color-default': 'var(--color-base)',
+						} as CSSProperties
+					}
+				>
+					<Background
+						color='rgba(255, 255, 255, 0.3)'
+						gap={GRID_SIZE}
+						variant={BackgroundVariant.Dots}
 					/>
-				</Panel>
-			</ReactFlow>
+
+					<MindMapTopBar
+						mapId={mapId as string}
+						mindMap={mindMap}
+						isMapReady={isMapReady}
+						currentUser={currentUser}
+						userProfile={userProfile}
+						activityState={activityState}
+						popoverOpen={popoverOpen}
+						canEdit={canEdit}
+						mobileUnreadCount={mobileNotifications.visibleUnreadCount}
+						handleToggleHistorySidebar={handleToggleHistorySidebar}
+						handleToggleMapSettings={handleToggleMapSettings}
+						handleToggleSharePanel={handleToggleSharePanel}
+						handleOpenSettings={handleOpenSettings}
+						mobileMenuOpen={mobileMenuOpen}
+						setMobileMenuOpen={setMobileMenuOpen}
+					/>
+
+					<Panel position='bottom-center'>
+						<div
+							ref={bottomDockRef}
+							className='flex flex-col gap-2 items-center'
+							data-testid='bottom-dock'
+						>
+							<ModeIndicator />
+
+							<Toolbar
+								isMapReady={isMapReady}
+								mobileTapMultiSelectEnabled={mobileTapMultiSelectEnabled}
+								onMobileTapMultiSelectChange={setMobileTapMultiSelectEnabled}
+							/>
+						</div>
+					</Panel>
+
+					<Panel className='m-4 pt-10' position='top-right'></Panel>
+
+					<Panel position='top-left'>
+						<RealtimeCursors
+							reactFlowInstance={reactFlowInstance}
+							roomName={getMindMapRoomName(mapId as string, 'cursor')}
+						/>
+					</Panel>
+				</ReactFlow>
+			</div>
 
 			<UpgradeModal
 				onOpenChange={(open) => setPopoverOpen({ upgradeUser: open })}

--- a/src/components/mind-map/react-flow-area.tsx
+++ b/src/components/mind-map/react-flow-area.tsx
@@ -45,6 +45,7 @@ import { useAnimatedLayout } from '@/hooks/use-animated-layout';
 import { useContextMenu } from '@/hooks/use-context-menu';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { useNodeSuggestion } from '@/hooks/use-node-suggestion';
+import { useTouchContextMenuFallback } from '@/hooks/use-touch-context-menu-fallback';
 import { getMindMapRoomName } from '@/lib/realtime/room-names';
 import useAppStore from '@/store/mind-map-store';
 import type { AppEdge } from '@/types/app-edge';
@@ -72,6 +73,7 @@ interface ReactFlowAreaProps {
 export function ReactFlowArea({ isMapReady }: ReactFlowAreaProps) {
 	const mapId = useParams().id;
 	const reactFlowInstance = useReactFlow();
+	const touchContextMenuContainerRef = useRef<HTMLDivElement | null>(null);
 	const bottomDockRef = useRef<HTMLDivElement | null>(null);
 	const connectingNodeId = useRef<string | null>(null);
 	const connectingHandleId = useRef<string | null>(null);
@@ -198,6 +200,12 @@ export function ReactFlowArea({ isMapReady }: ReactFlowAreaProps) {
 	const mobileNotifications = useNotifications({
 		filterMapId: mapId as string,
 		enabled: isMobile,
+	});
+
+	useTouchContextMenuFallback({
+		containerRef: touchContextMenuContainerRef,
+		isContextMenuOpen: popoverOpen.contextMenu,
+		openContextMenuAt: contextMenuHandlers.openContextMenuAt,
 	});
 	const updateBottomToolbarClearance = useCallback(() => {
 		if (typeof window === 'undefined') return;
@@ -732,7 +740,11 @@ export function ReactFlowArea({ isMapReady }: ReactFlowAreaProps) {
 	}, [showUpgradeModal]);
 
 	return (
-		<div className='w-full h-full' key='mind-map-container'>
+		<div
+			className='w-full h-full'
+			key='mind-map-container'
+			ref={touchContextMenuContainerRef}
+		>
 			<ReactFlow
 				colorMode='dark'
 				connectionLineComponent={FloatingConnectionLine}

--- a/src/hooks/use-context-menu.test.ts
+++ b/src/hooks/use-context-menu.test.ts
@@ -1,0 +1,67 @@
+import { act, renderHook } from '@testing-library/react';
+import { useContextMenu } from './use-context-menu';
+
+let mockStoreState: Record<string, unknown>;
+
+jest.mock('@/store/mind-map-store', () => ({
+	__esModule: true,
+	default: (selector: (state: Record<string, unknown>) => unknown) =>
+		selector(mockStoreState),
+}));
+
+jest.mock('zustand/shallow', () => ({
+	useShallow: <T,>(selector: T) => selector,
+}));
+
+describe('useContextMenu', () => {
+	const setPopoverOpen = jest.fn();
+	const setContextMenuState = jest.fn();
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		mockStoreState = {
+			reactFlowInstance: null,
+			contextMenuState: {
+				x: 0,
+				y: 0,
+				nodeId: null,
+				edgeId: null,
+			},
+			popoverOpen: {
+				contextMenu: false,
+			},
+			setPopoverOpen,
+			setContextMenuState,
+			activeTool: 'default',
+			setActiveTool: jest.fn(),
+			addNode: jest.fn(),
+			deleteNodes: jest.fn(),
+			isCommentMode: false,
+			createComment: jest.fn(),
+			mapId: 'map-1',
+			currentUser: { id: 'user-1' },
+			handleOnboardingCanvasNodeCreated: jest.fn(),
+		};
+	});
+
+	it('openContextMenuAt opens the menu and sets coordinates/targets', () => {
+		const { result } = renderHook(() => useContextMenu());
+
+		act(() => {
+			result.current.contextMenuHandlers.openContextMenuAt({
+				x: 144,
+				y: 233,
+				nodeId: 'node-7',
+			});
+		});
+
+		expect(setPopoverOpen).toHaveBeenCalledWith({ contextMenu: true });
+		expect(setContextMenuState).toHaveBeenCalledWith({
+			x: 144,
+			y: 233,
+			nodeId: 'node-7',
+			edgeId: null,
+		});
+	});
+});

--- a/src/hooks/use-context-menu.ts
+++ b/src/hooks/use-context-menu.ts
@@ -13,12 +13,20 @@ interface ContextMenuHandlers {
 	onPaneContextMenu: (event: ReactMouseEvent | MouseEvent) => void;
 	onEdgeContextMenu: EdgeMouseHandler<Edge<Partial<EdgeData>>>;
 	onPaneClick: (event: ReactMouseEvent) => void;
+	openContextMenuAt: (params: OpenContextMenuAtParams) => void;
 	close: () => void;
 }
 
 interface UseContextMenuResult {
 	contextMenuState: ContextMenuState | null;
 	contextMenuHandlers: ContextMenuHandlers;
+}
+
+export interface OpenContextMenuAtParams {
+	x: number;
+	y: number;
+	nodeId?: string | null;
+	edgeId?: string | null;
 }
 
 export function useContextMenu(): UseContextMenuResult {
@@ -60,47 +68,58 @@ export function useContextMenu(): UseContextMenuResult {
 		}))
 	);
 
-	const onNodeContextMenu = useCallback(
-		(event: ReactMouseEvent, node: Node<NodeData>) => {
-			event.preventDefault();
+	const openContextMenuAt = useCallback(
+		({ x, y, nodeId = null, edgeId = null }: OpenContextMenuAtParams) => {
 			setPopoverOpen({
 				contextMenu: true,
 			});
 			setContextMenuState({
+				x,
+				y,
+				nodeId,
+				edgeId,
+			});
+		},
+		[setPopoverOpen, setContextMenuState]
+	);
+
+	const onNodeContextMenu = useCallback(
+		(event: ReactMouseEvent, node: Node<NodeData>) => {
+			event.preventDefault();
+			openContextMenuAt({
 				x: event.clientX,
 				y: event.clientY,
 				nodeId: node.id,
 				edgeId: null,
 			});
 		},
-		[setPopoverOpen, setContextMenuState]
+		[openContextMenuAt]
 	);
 
 	const onEdgeContextMenu = useCallback(
 		(event: ReactMouseEvent, edge: Edge<Partial<EdgeData>>) => {
 			event.preventDefault();
-			setContextMenuState({
+			openContextMenuAt({
 				x: event.clientX,
 				y: event.clientY,
 				nodeId: null,
 				edgeId: edge.id,
 			});
-			setPopoverOpen({
-				contextMenu: true,
-			});
 		},
-		[setPopoverOpen, setContextMenuState]
+		[openContextMenuAt]
 	);
 
 	const onPaneContextMenu = useCallback(
 		(event: ReactMouseEvent | MouseEvent) => {
 			event.preventDefault();
 
-			const target = event.target as Element;
+			const target = event.target;
+			const isElementTarget = target instanceof Element;
 
 			if (
-				target.closest('.react-flow__node') ||
-				target.closest('.react-flow__edge')
+				isElementTarget &&
+				(target.closest('.react-flow__node') ||
+					target.closest('.react-flow__edge'))
 			) {
 				if (popoverOpen.contextMenu) {
 					setPopoverOpen({
@@ -117,17 +136,14 @@ export function useContextMenu(): UseContextMenuResult {
 				return;
 			}
 
-			setPopoverOpen({
-				contextMenu: true,
-			});
-			setContextMenuState({
+			openContextMenuAt({
 				x: event.clientX,
 				y: event.clientY,
 				nodeId: null,
 				edgeId: null,
 			});
 		},
-		[setPopoverOpen, setContextMenuState]
+		[openContextMenuAt, popoverOpen.contextMenu, setPopoverOpen, setContextMenuState]
 	);
 
 	const closeContextMenu = useCallback(() => {
@@ -262,6 +278,7 @@ export function useContextMenu(): UseContextMenuResult {
 			onEdgeContextMenu,
 			onPaneContextMenu,
 			onPaneClick,
+			openContextMenuAt,
 			close: closeContextMenu,
 		},
 	};

--- a/src/hooks/use-touch-context-menu-fallback.test.tsx
+++ b/src/hooks/use-touch-context-menu-fallback.test.tsx
@@ -1,0 +1,236 @@
+import { act, render, screen } from '@testing-library/react';
+import { useRef } from 'react';
+import type { OpenContextMenuAtParams } from './use-context-menu';
+import {
+	TOUCH_CONTEXT_MENU_CLICK_SUPPRESSION_MS,
+	TOUCH_CONTEXT_MENU_LONG_PRESS_MS,
+	useTouchContextMenuFallback,
+} from './use-touch-context-menu-fallback';
+
+type PointerEventInitWithTouch = PointerEventInit & {
+	pointerType?: string;
+	isPrimary?: boolean;
+};
+
+class MockPointerEvent extends MouseEvent {
+	pointerId: number;
+	pointerType: string;
+	isPrimary: boolean;
+
+	constructor(type: string, init: PointerEventInitWithTouch = {}) {
+		super(type, init);
+		this.pointerId = init.pointerId ?? 1;
+		this.pointerType = init.pointerType ?? 'touch';
+		this.isPrimary = init.isPrimary ?? true;
+	}
+}
+
+function dispatchPointerEvent(
+	target: Element,
+	type: string,
+	init: PointerEventInitWithTouch = {}
+) {
+	const PointerEventConstructor =
+		(window.PointerEvent as typeof PointerEvent | undefined) ?? MockPointerEvent;
+
+	const event = new PointerEventConstructor(type, {
+		bubbles: true,
+		cancelable: true,
+		button: 0,
+		clientX: 100,
+		clientY: 100,
+		pointerId: 1,
+		pointerType: 'touch',
+		isPrimary: true,
+		...init,
+	});
+
+	target.dispatchEvent(event);
+	return event;
+}
+
+function TouchContextMenuHarness({
+	openContextMenuAt,
+	isContextMenuOpen = false,
+}: {
+	openContextMenuAt: (params: OpenContextMenuAtParams) => void;
+	isContextMenuOpen?: boolean;
+}) {
+	const containerRef = useRef<HTMLDivElement | null>(null);
+
+	useTouchContextMenuFallback({
+		containerRef,
+		openContextMenuAt,
+		isContextMenuOpen,
+	});
+
+	return (
+		<div data-testid='container' ref={containerRef}>
+			<div className='react-flow__pane' data-testid='pane'>
+				<div className='react-flow__node' data-id='node-1' data-testid='node'>
+					<span data-testid='node-child'>Node</span>
+				</div>
+				<svg>
+					<g className='react-flow__edge' data-id='edge-1' data-testid='edge'>
+						<path data-testid='edge-path' />
+					</g>
+				</svg>
+			</div>
+		</div>
+	);
+}
+
+describe('useTouchContextMenuFallback', () => {
+	const originalPointerEvent = window.PointerEvent;
+
+	beforeAll(() => {
+		if (!window.PointerEvent) {
+			Object.defineProperty(window, 'PointerEvent', {
+				configurable: true,
+				writable: true,
+				value: MockPointerEvent,
+			});
+		}
+	});
+
+	afterAll(() => {
+		Object.defineProperty(window, 'PointerEvent', {
+			configurable: true,
+			writable: true,
+			value: originalPointerEvent,
+		});
+	});
+
+	beforeEach(() => {
+		jest.useFakeTimers();
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+		jest.clearAllMocks();
+	});
+
+	it('opens the menu after long-press on a node', () => {
+		const openContextMenuAt = jest.fn();
+		render(<TouchContextMenuHarness openContextMenuAt={openContextMenuAt} />);
+
+		const nodeChild = screen.getByTestId('node-child');
+		act(() => {
+			dispatchPointerEvent(nodeChild, 'pointerdown', {
+				clientX: 120,
+				clientY: 80,
+			});
+			jest.advanceTimersByTime(TOUCH_CONTEXT_MENU_LONG_PRESS_MS);
+		});
+
+		expect(openContextMenuAt).toHaveBeenCalledTimes(1);
+		expect(openContextMenuAt).toHaveBeenCalledWith({
+			x: 120,
+			y: 80,
+			nodeId: 'node-1',
+			edgeId: null,
+		});
+	});
+
+	it('opens the menu after long-press on an edge', () => {
+		const openContextMenuAt = jest.fn();
+		render(<TouchContextMenuHarness openContextMenuAt={openContextMenuAt} />);
+
+		const edgePath = screen.getByTestId('edge-path');
+		act(() => {
+			dispatchPointerEvent(edgePath, 'pointerdown', {
+				clientX: 64,
+				clientY: 48,
+			});
+			jest.advanceTimersByTime(TOUCH_CONTEXT_MENU_LONG_PRESS_MS);
+		});
+
+		expect(openContextMenuAt).toHaveBeenCalledTimes(1);
+		expect(openContextMenuAt).toHaveBeenCalledWith({
+			x: 64,
+			y: 48,
+			nodeId: null,
+			edgeId: 'edge-1',
+		});
+	});
+
+	it('opens the menu after long-press on pane', () => {
+		const openContextMenuAt = jest.fn();
+		render(<TouchContextMenuHarness openContextMenuAt={openContextMenuAt} />);
+
+		const pane = screen.getByTestId('pane');
+		act(() => {
+			dispatchPointerEvent(pane, 'pointerdown', {
+				clientX: 300,
+				clientY: 220,
+			});
+			jest.advanceTimersByTime(TOUCH_CONTEXT_MENU_LONG_PRESS_MS);
+		});
+
+		expect(openContextMenuAt).toHaveBeenCalledTimes(1);
+		expect(openContextMenuAt).toHaveBeenCalledWith({
+			x: 300,
+			y: 220,
+			nodeId: null,
+			edgeId: null,
+		});
+	});
+
+	it('does not open the menu on quick tap', () => {
+		const openContextMenuAt = jest.fn();
+		render(<TouchContextMenuHarness openContextMenuAt={openContextMenuAt} />);
+
+		const node = screen.getByTestId('node');
+		act(() => {
+			dispatchPointerEvent(node, 'pointerdown');
+			jest.advanceTimersByTime(200);
+			dispatchPointerEvent(node, 'pointerup');
+			jest.advanceTimersByTime(TOUCH_CONTEXT_MENU_LONG_PRESS_MS);
+		});
+
+		expect(openContextMenuAt).not.toHaveBeenCalled();
+	});
+
+	it('does not open the menu when movement exceeds threshold', () => {
+		const openContextMenuAt = jest.fn();
+		render(<TouchContextMenuHarness openContextMenuAt={openContextMenuAt} />);
+
+		const node = screen.getByTestId('node');
+		act(() => {
+			dispatchPointerEvent(node, 'pointerdown', { clientX: 100, clientY: 100 });
+			dispatchPointerEvent(node, 'pointermove', { clientX: 113, clientY: 100 });
+			jest.advanceTimersByTime(TOUCH_CONTEXT_MENU_LONG_PRESS_MS);
+		});
+
+		expect(openContextMenuAt).not.toHaveBeenCalled();
+	});
+
+	it('suppresses the immediate trailing click after long-press', () => {
+		const openContextMenuAt = jest.fn();
+		render(<TouchContextMenuHarness openContextMenuAt={openContextMenuAt} />);
+
+		const node = screen.getByTestId('node');
+		act(() => {
+			dispatchPointerEvent(node, 'pointerdown');
+			jest.advanceTimersByTime(TOUCH_CONTEXT_MENU_LONG_PRESS_MS);
+		});
+
+		const firstClick = new MouseEvent('click', {
+			bubbles: true,
+			cancelable: true,
+		});
+		node.dispatchEvent(firstClick);
+		expect(firstClick.defaultPrevented).toBe(true);
+
+		act(() => {
+			jest.advanceTimersByTime(TOUCH_CONTEXT_MENU_CLICK_SUPPRESSION_MS + 1);
+		});
+
+		const secondClick = new MouseEvent('click', {
+			bubbles: true,
+			cancelable: true,
+		});
+		node.dispatchEvent(secondClick);
+		expect(secondClick.defaultPrevented).toBe(false);
+	});
+});

--- a/src/hooks/use-touch-context-menu-fallback.test.tsx
+++ b/src/hooks/use-touch-context-menu-fallback.test.tsx
@@ -233,4 +233,42 @@ describe('useTouchContextMenuFallback', () => {
 		node.dispatchEvent(secondClick);
 		expect(secondClick.defaultPrevented).toBe(false);
 	});
+
+	it('does not open from timeout after native contextmenu opens first', () => {
+		const openContextMenuAt = jest.fn();
+		const { rerender } = render(
+			<TouchContextMenuHarness
+				isContextMenuOpen={false}
+				openContextMenuAt={openContextMenuAt}
+			/>
+		);
+
+		const node = screen.getByTestId('node');
+		act(() => {
+			dispatchPointerEvent(node, 'pointerdown', {
+				clientX: 140,
+				clientY: 90,
+			});
+		});
+
+		const nativeContextMenuEvent = new MouseEvent('contextmenu', {
+			bubbles: true,
+			cancelable: true,
+		});
+		node.dispatchEvent(nativeContextMenuEvent);
+
+		// Simulate store update after native context menu opened.
+		rerender(
+			<TouchContextMenuHarness
+				isContextMenuOpen={true}
+				openContextMenuAt={openContextMenuAt}
+			/>
+		);
+
+		act(() => {
+			jest.advanceTimersByTime(TOUCH_CONTEXT_MENU_LONG_PRESS_MS);
+		});
+
+		expect(openContextMenuAt).not.toHaveBeenCalled();
+	});
 });

--- a/src/hooks/use-touch-context-menu-fallback.ts
+++ b/src/hooks/use-touch-context-menu-fallback.ts
@@ -47,6 +47,34 @@ function resolveTargetContext(target: EventTarget | null): TargetContext | null 
 	return null;
 }
 
+/**
+ * Adds a touch long-press fallback for opening the custom context menu inside
+ * the provided React Flow container.
+ *
+ * Targets:
+ * - `.react-flow__node[data-id]` -> opens node context menu.
+ * - `.react-flow__edge[data-id]` -> opens edge context menu.
+ * - `.react-flow__pane` -> opens pane context menu.
+ *
+ * Detection:
+ * - Requires primary touch pointer and left button (`pointerdown`).
+ * - Opens after `TOUCH_CONTEXT_MENU_LONG_PRESS_MS`.
+ * - Cancels when pointer moves more than `TOUCH_CONTEXT_MENU_MOVE_TOLERANCE_PX`,
+ *   or on `pointerup`/`pointercancel`/`pointerleave`, or window scroll.
+ *
+ * Suppression:
+ * - No new press starts while `isContextMenuOpen` is true.
+ * - After a successful long-press open, suppresses immediate trailing
+ *   `click/contextmenu` events for
+ *   `TOUCH_CONTEXT_MENU_CLICK_SUPPRESSION_MS` to prevent accidental
+ *   close/select side effects.
+ *
+ * Internal refs:
+ * - `pendingPressRef`: active touch candidate (pointer id/start coords/target).
+ * - `timerIdRef`: pending long-press timer id.
+ * - `isContextMenuOpenRef`: latest menu-open state for race-safe checks.
+ * - `suppressClickUntilRef`: timestamp gate for trailing event suppression.
+ */
 export function useTouchContextMenuFallback({
 	containerRef,
 	openContextMenuAt,
@@ -109,6 +137,10 @@ export function useTouchContextMenuFallback({
 				if (!pendingPress || pendingPress.pointerId !== pointerId) {
 					return;
 				}
+				if (isContextMenuOpenRef.current) {
+					clearPendingPress();
+					return;
+				}
 
 				openContextMenuAtRef.current({
 					x: pendingPress.startX,
@@ -162,6 +194,7 @@ export function useTouchContextMenuFallback({
 				return;
 			}
 
+			clearPendingPress();
 			event.preventDefault();
 			event.stopPropagation();
 			event.stopImmediatePropagation();

--- a/src/hooks/use-touch-context-menu-fallback.ts
+++ b/src/hooks/use-touch-context-menu-fallback.ts
@@ -1,0 +1,195 @@
+import { type RefObject, useEffect, useRef } from 'react';
+import type { OpenContextMenuAtParams } from './use-context-menu';
+
+export const TOUCH_CONTEXT_MENU_LONG_PRESS_MS = 500;
+export const TOUCH_CONTEXT_MENU_MOVE_TOLERANCE_PX = 12;
+export const TOUCH_CONTEXT_MENU_CLICK_SUPPRESSION_MS = 750;
+
+interface UseTouchContextMenuFallbackParams {
+	containerRef: RefObject<HTMLElement | null>;
+	openContextMenuAt: (params: OpenContextMenuAtParams) => void;
+	isContextMenuOpen: boolean;
+}
+
+interface TargetContext {
+	nodeId: string | null;
+	edgeId: string | null;
+}
+
+interface PendingTouchContextMenu {
+	pointerId: number;
+	startX: number;
+	startY: number;
+	context: TargetContext;
+}
+
+function resolveTargetContext(target: EventTarget | null): TargetContext | null {
+	if (!(target instanceof Element)) {
+		return null;
+	}
+
+	const nodeElement = target.closest<HTMLElement>('.react-flow__node[data-id]');
+	const nodeId = nodeElement?.getAttribute('data-id');
+	if (nodeId) {
+		return { nodeId, edgeId: null };
+	}
+
+	const edgeElement = target.closest<HTMLElement>('.react-flow__edge[data-id]');
+	const edgeId = edgeElement?.getAttribute('data-id');
+	if (edgeId) {
+		return { nodeId: null, edgeId };
+	}
+
+	if (target.closest('.react-flow__pane')) {
+		return { nodeId: null, edgeId: null };
+	}
+
+	return null;
+}
+
+export function useTouchContextMenuFallback({
+	containerRef,
+	openContextMenuAt,
+	isContextMenuOpen,
+}: UseTouchContextMenuFallbackParams) {
+	const openContextMenuAtRef = useRef(openContextMenuAt);
+	const isContextMenuOpenRef = useRef(isContextMenuOpen);
+	const timerIdRef = useRef<number | null>(null);
+	const pendingPressRef = useRef<PendingTouchContextMenu | null>(null);
+	const suppressClickUntilRef = useRef(0);
+
+	useEffect(() => {
+		openContextMenuAtRef.current = openContextMenuAt;
+	}, [openContextMenuAt]);
+
+	useEffect(() => {
+		isContextMenuOpenRef.current = isContextMenuOpen;
+	}, [isContextMenuOpen]);
+
+	useEffect(() => {
+		const container = containerRef.current;
+		if (!container) {
+			return;
+		}
+
+		const clearPendingPress = () => {
+			if (timerIdRef.current !== null) {
+				window.clearTimeout(timerIdRef.current);
+				timerIdRef.current = null;
+			}
+			pendingPressRef.current = null;
+		};
+
+		const onPointerDown = (event: PointerEvent) => {
+			if (event.pointerType !== 'touch' || event.button !== 0) {
+				return;
+			}
+
+			if (event.isPrimary === false || isContextMenuOpenRef.current) {
+				return;
+			}
+
+			const context = resolveTargetContext(event.target);
+			if (!context) {
+				return;
+			}
+
+			clearPendingPress();
+
+			const pointerId = event.pointerId;
+			pendingPressRef.current = {
+				pointerId,
+				startX: event.clientX,
+				startY: event.clientY,
+				context,
+			};
+
+			timerIdRef.current = window.setTimeout(() => {
+				const pendingPress = pendingPressRef.current;
+				if (!pendingPress || pendingPress.pointerId !== pointerId) {
+					return;
+				}
+
+				openContextMenuAtRef.current({
+					x: pendingPress.startX,
+					y: pendingPress.startY,
+					nodeId: pendingPress.context.nodeId,
+					edgeId: pendingPress.context.edgeId,
+				});
+
+				suppressClickUntilRef.current =
+					Date.now() + TOUCH_CONTEXT_MENU_CLICK_SUPPRESSION_MS;
+				clearPendingPress();
+			}, TOUCH_CONTEXT_MENU_LONG_PRESS_MS);
+		};
+
+		const onPointerMove = (event: PointerEvent) => {
+			const pendingPress = pendingPressRef.current;
+			if (!pendingPress || pendingPress.pointerId !== event.pointerId) {
+				return;
+			}
+
+			const movement = Math.hypot(
+				event.clientX - pendingPress.startX,
+				event.clientY - pendingPress.startY
+			);
+
+			if (movement > TOUCH_CONTEXT_MENU_MOVE_TOLERANCE_PX) {
+				clearPendingPress();
+			}
+		};
+
+		const onPointerUp = (event: PointerEvent) => {
+			const pendingPress = pendingPressRef.current;
+			if (pendingPress && pendingPress.pointerId === event.pointerId) {
+				clearPendingPress();
+			}
+		};
+
+		const suppressTrailingClick = (event: MouseEvent) => {
+			if (Date.now() > suppressClickUntilRef.current) {
+				return;
+			}
+
+			event.preventDefault();
+			event.stopPropagation();
+			event.stopImmediatePropagation();
+			suppressClickUntilRef.current = 0;
+		};
+
+		const suppressTrailingContextMenu = (event: MouseEvent) => {
+			if (Date.now() > suppressClickUntilRef.current) {
+				return;
+			}
+
+			event.preventDefault();
+			event.stopPropagation();
+			event.stopImmediatePropagation();
+		};
+
+		container.addEventListener('pointerdown', onPointerDown);
+		container.addEventListener('pointermove', onPointerMove);
+		container.addEventListener('pointerup', onPointerUp);
+		container.addEventListener('pointercancel', onPointerUp);
+		container.addEventListener('pointerleave', onPointerUp);
+		container.addEventListener('click', suppressTrailingClick, true);
+		container.addEventListener('contextmenu', suppressTrailingContextMenu, true);
+		window.addEventListener('scroll', clearPendingPress, true);
+
+		return () => {
+			clearPendingPress();
+			container.removeEventListener('pointerdown', onPointerDown);
+			container.removeEventListener('pointermove', onPointerMove);
+			container.removeEventListener('pointerup', onPointerUp);
+			container.removeEventListener('pointercancel', onPointerUp);
+			container.removeEventListener('pointerleave', onPointerUp);
+			container.removeEventListener('click', suppressTrailingClick, true);
+			container.removeEventListener(
+				'contextmenu',
+				suppressTrailingContextMenu,
+				true
+			);
+			window.removeEventListener('scroll', clearPendingPress, true);
+		};
+	}, [containerRef]);
+}


### PR DESCRIPTION
## Summary
- add a touch long-press fallback for React Flow context menu activation on mobile/iPad
- keep existing desktop/native `contextmenu` behavior unchanged
- centralize context-menu opening via `openContextMenuAt(...)` in `useContextMenu`
- wire fallback into the map shell and suppress trailing synthetic click/contextmenu after long-press
- add regression tests for long-press target resolution/cancellation/suppression and `openContextMenuAt` state wiring
- update `CHANGELOG.md` and `CLAUDE.md` with the new mobile context-menu gotcha/contract

## Why
iPad (including Chrome on iPad, which uses iOS WebKit behavior) does not reliably emit native `contextmenu` for press-and-hold. This made context-menu-only actions inaccessible on touch.

## Testing
- `pnpm test -- src/hooks/use-context-menu.test.ts src/hooks/use-touch-context-menu-fallback.test.tsx src/components/mind-map/react-flow-area.test.tsx`
- `pnpm type-check`

## Scope
- no backend/API/schema changes
- internal hook contract change only: `useContextMenu().contextMenuHandlers` now includes `openContextMenuAt`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added touch long-press context menu support for mobile and tablet users on React Flow elements (nodes, edges, and canvas)
  * Long-press opens the context menu with automatic prevention of accidental trailing clicks

* **Tests**
  * Added comprehensive test coverage for touch long-press interactions, movement handling, and event suppression behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->