### PR TITLE
fix: show node editor completions on iPad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,13 @@ Format: `[YYYY-MM-DD]` - one entry per day.
 
 - **node-editor/ipad-autocomplete-tray**: iPad/tablet touch viewports now use the visible React autocomplete tray instead of relying on the native CodeMirror popup, so suggestions remain visible while keyboard selection still works.
   - Why: Desktop-width iPad Safari could keep autocomplete active but hide the visual popup.
+- **tooling/eslint-flat-config**: ESLint now imports Next.js 16 flat config exports directly instead of routing them through `FlatCompat`, pins the React lint setting to the app's React version, and keeps Jest test mock patterns out of production-only lint restrictions so CodeRabbit and local lint can load the config without crashing.
+  - Why: ESLint 10 legacy config validation is incompatible with the flat plugin objects exported by the current Next lint stack, and React version auto-detection still calls an ESLint 9-era rule-context API.
 
 ### Docs
 
 - **node-editor/autocomplete-surface-contract**: Updated the documented autocomplete contract for touch-first iPad/tablet widths.
+- **tooling/eslint-flat-config-contract**: Documented the direct Next flat-config import requirement for future lint-stack updates.
 
 ## [2026-05-14]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Format: `[YYYY-MM-DD]` - one entry per day.
 
 ---
 
+## [2026-05-15]
+
+### Fixed
+
+- **node-editor/ipad-autocomplete-tray**: iPad/tablet touch viewports now use the visible React autocomplete tray instead of relying on the native CodeMirror popup, so suggestions remain visible while keyboard selection still works.
+  - Why: Desktop-width iPad Safari could keep autocomplete active but hide the visual popup.
+
+### Docs
+
+- **node-editor/autocomplete-surface-contract**: Updated the documented autocomplete contract for touch-first iPad/tablet widths.
+
 ## [2026-05-14]
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,10 @@ pnpm pretty          # Prettier
 
 <!-- Updated: 2026-04-09 - Documented CI pnpm version-source conflict guardrail -->
 
+**ESLint flat config**: Next.js 16's `eslint-config-next/*` exports flat config arrays. Import those exports directly in `eslint.config.mjs`; do not wrap them in `FlatCompat`, because ESLint 10 legacy config validation can crash on circular plugin objects from `eslint-plugin-react`. Keep `settings.react.version` explicit rather than `detect` while the current React plugin is on the ESLint 9-era context API.
+
+<!-- Updated: 2026-05-15 - Documented direct Next flat-config imports and explicit React version for ESLint 10 compatibility -->
+
 **LAN-safe local dev URLs**: Browser Supabase + PartyKit clients must derive from `window.location.hostname` whenever the configured public URL is loopback-only and the browser host is non-loopback (LAN device access), even if client `NODE_ENV` is unavailable. Keep server-side Supabase traffic on `SUPABASE_INTERNAL_URL` when local services stay on loopback, and do not reintroduce `NEXT_PUBLIC_APP_LOCAL_HREF` for browser fetches.
 
 <!-- Updated: 2026-04-12 - Documented LAN-safe browser-vs-server URL split and NODE_ENV-independent loopback-to-LAN derivation -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,9 +188,9 @@ For title metadata use lowercase quoted syntax `title:"..."` (not `Title:`).
 
 <!-- Updated: 2026-04-08 - Documented task-node hide-completed persistence and title round-trip contract -->
 
-**Node editor autocomplete surfaces**: Keep `createCompletions()` as the single source of autocomplete options. Desktop uses the native CodeMirror tooltip; mobile hides that tooltip and renders a hybrid presenter: a compact full-width strip attached to the open keyboard, or a caret-anchored floating panel when the keyboard is hidden. Any editor/modal outside-press guard must treat both `[data-node-editor-autocomplete-tray="true"]` and body-portaled `.cm-tooltip*` elements as inside-editor interactions so selecting a suggestion does not dismiss the editor.
+**Node editor autocomplete surfaces**: Keep `createCompletions()` as the single source of autocomplete options. Desktop pointer/hover contexts use the native CodeMirror tooltip; touch-first mobile/tablet/iPad contexts hide that tooltip and render a hybrid presenter, even when viewport width is desktop-sized: a compact full-width strip attached to the open keyboard, or a caret-anchored floating panel when the keyboard is hidden. Any editor/modal outside-press guard must treat both `[data-node-editor-autocomplete-tray="true"]` and body-portaled `.cm-tooltip*` elements as inside-editor interactions so selecting a suggestion does not dismiss the editor.
 
-<!-- Updated: 2026-03-28 - Documented the hybrid mobile autocomplete presenter and shared completion engine -->
+<!-- Updated: 2026-05-15 - Documented touch-qualified autocomplete presenter selection for iPad/tablet widths -->
 
 **Touch context menu fallback**: Do not rely on native `contextmenu` alone for mobile/iPad. Keep `useTouchContextMenuFallback` wired to the React Flow shell so touch long-press on `.react-flow__node[data-id]`, `.react-flow__edge[data-id]`, or `.react-flow__pane` opens the same context-menu store state path (`openContextMenuAt`) used by desktop right-click handlers. Preserve movement cancellation and trailing click/contextmenu suppression to avoid accidental immediate close/select side-effects after long-press activation.
 

--- a/docs/CODEBASE_MAP.md
+++ b/docs/CODEBASE_MAP.md
@@ -32,7 +32,7 @@ total_tokens: 707972
 <!-- Updated: 2026-04-15 - Documented numeric node-id aliasing across row-based AI routes -->
 <!-- Updated: 2026-04-15 - Documented typed AI suggestion payloads and ghost approval for safe typed nodes -->
 <!-- Updated: 2026-03-28 - Documented stale-safe layout normalization writes and in-flight animation synchronization after CodeRabbit review -->
-<!-- Updated: 2026-03-28 - Documented mobile node-editor autocomplete tray and shared completion-state bridge -->
+<!-- Updated: 2026-05-15 - Documented touch-qualified node-editor autocomplete tray selection for iPad/tablet widths -->
 <!-- Updated: 2026-03-29 - Documented autocomplete overlay portal dismissal contract and runtime visibility bridge responsibilities -->
 <!-- Updated: 2026-04-01 - Documented LAN-safe local-dev Supabase/PartyKit URL derivation -->
 <!-- Updated: 2026-04-01 - Documented stable Supabase SSR auth storage key for LAN logins -->
@@ -438,8 +438,9 @@ Task-title metadata uses lowercase quoted syntax `title:"..."` (not `Title:`).
 
 **Node Editor Autocomplete:**
 
-- `src/components/node-editor/integrations/codemirror/setup.ts` mirrors CodeMirror completion visibility into React and owns the native-tooltip suppression toggle, so the app still knows autocomplete is logically open even when mobile hides the native popup
+- `src/components/node-editor/integrations/codemirror/setup.ts` mirrors CodeMirror completion visibility into React and owns the native-tooltip suppression toggle, so the app still knows autocomplete is logically open even when touch-first mobile/tablet/iPad viewports hide the native popup
 - `src/components/node-editor/integrations/codemirror/autocomplete-state.ts` is the shared bridge for reading `active/pending`, current options, selected index, and caret/editor geometry from CodeMirror; those snapshots are what let the mobile tray and dismissal guards stay aligned with the live editor selection
+- `src/components/node-editor/components/inputs/quick-input.tsx` selects that touch presenter from width, primary pointer/hover media, and desktop-class iPad touch signals so iPad/tablet widths do not fall back to the native CodeMirror tooltip
 - `src/components/node-editor/components/inputs/mobile-completion-tray.tsx` portals into the `[data-node-editor-overlay="true"]` overlay instead of `document.body`, while `src/components/node-editor/components/inputs/use-mobile-autocomplete-viewport.ts` supplies the `visualViewport`/keyboard heuristics that keep that overlay-local surface attached to the keyboard or anchored below the typed text
 - Outside-click boundaries must exclude both `[data-node-editor-autocomplete-tray="true"]` and body-portaled `.cm-tooltip*` elements so tray taps, tray scroll gestures, and native CodeMirror suggestion taps do not dismiss the editor; update `src/components/node-editor/node-editor.tsx` (`useDismiss(... outsidePress ...)`) and any future modal/editor wrapper dismissal checks if the overlay boundary or portal target changes
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,19 +1,19 @@
-import { FlatCompat } from '@eslint/eslintrc';
 import stylistic from '@stylistic/eslint-plugin';
-import { dirname } from 'path';
-import { fileURLToPath } from 'url';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-const compat = new FlatCompat({
-	baseDirectory: __dirname,
-});
+import nextVitals from 'eslint-config-next/core-web-vitals';
+import nextTypescript from 'eslint-config-next/typescript';
 
 const eslintConfig = [
-	...compat.extends('next/core-web-vitals', 'next/typescript'),
+	...nextVitals,
+	...nextTypescript,
 	{
 		ignores: ['.next/**', 'node_modules/**', 'next-env.d.ts', 'globals.css'],
+	},
+	{
+		settings: {
+			react: {
+				version: '19.2',
+			},
+		},
 	},
 	{
 		rules: {
@@ -49,6 +49,13 @@ const eslintConfig = [
 					ignoreCase: true,
 				},
 			],
+		},
+	},
+	{
+		files: ['**/*.test.{ts,tsx}', '**/*.spec.{ts,tsx}'],
+		rules: {
+			'@stylistic/jsx-newline': 'off',
+			'@typescript-eslint/no-require-imports': 'off',
 		},
 	},
 ];

--- a/src/components/node-editor/components/inputs/quick-input.test.tsx
+++ b/src/components/node-editor/components/inputs/quick-input.test.tsx
@@ -576,6 +576,8 @@ function createQuickInputNode(
 }
 
 describe('QuickInput', () => {
+	const originalMatchMedia = window.matchMedia;
+
 	const defaultProps = {
 		nodeType: 'defaultNode' as const,
 		parentNode: null,
@@ -592,6 +594,27 @@ describe('QuickInput', () => {
 		expect(
 			first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING
 		).toBeTruthy();
+	};
+
+	const mockTouchAutocompleteMedia = ({
+		coarsePointer = false,
+		noHover = false,
+	}: {
+		coarsePointer?: boolean;
+		noHover?: boolean;
+	}) => {
+		window.matchMedia = jest.fn((query: string) => ({
+			matches:
+				(query.includes('pointer: coarse') && coarsePointer) ||
+				(query.includes('hover: none') && noHover),
+			media: query,
+			onchange: null,
+			addEventListener: jest.fn(),
+			removeEventListener: jest.fn(),
+			addListener: jest.fn(),
+			removeListener: jest.fn(),
+			dispatchEvent: jest.fn(),
+		})) as unknown as typeof window.matchMedia;
 	};
 
 	beforeEach(() => {
@@ -616,6 +639,10 @@ describe('QuickInput', () => {
 			limitInfo: null,
 			limitMessage: null,
 		});
+	});
+
+	afterEach(() => {
+		window.matchMedia = originalMatchMedia;
 	});
 
 	describe('rendering', () => {
@@ -843,6 +870,27 @@ describe('QuickInput', () => {
 			expect(screen.getByTestId('mobile-completion-tray')).toHaveAttribute(
 				'data-editor-focused',
 				'false'
+			);
+		});
+
+		it('uses the touch autocomplete tray on iPad-sized coarse pointer viewports', async () => {
+			const user = userEvent.setup();
+			mockIsMobile = false;
+			mockTouchAutocompleteMedia({ coarsePointer: true, noHover: true });
+
+			render(<QuickInput {...defaultProps} />);
+
+			await waitFor(() => {
+				expect(
+					screen.getByTestId('enhanced-input').parentElement
+				).toHaveAttribute('data-show-native-autocomplete', 'false');
+			});
+
+			await user.click(screen.getByTestId('emit-active-autocomplete'));
+
+			expect(screen.getByTestId('mobile-completion-tray')).toHaveAttribute(
+				'data-option-count',
+				'2'
 			);
 		});
 	});

--- a/src/components/node-editor/components/inputs/quick-input.tsx
+++ b/src/components/node-editor/components/inputs/quick-input.tsx
@@ -172,6 +172,69 @@ const shouldAutoProcessSwitch = (
 	return !!command?.nodeType;
 };
 
+function matchesMediaQuery(query: string): boolean {
+	if (typeof window === 'undefined' || !window.matchMedia) {
+		return false;
+	}
+
+	return window.matchMedia(query).matches;
+}
+
+function isDesktopClassIpad(): boolean {
+	if (typeof navigator === 'undefined') {
+		return false;
+	}
+
+	return (
+		navigator.maxTouchPoints > 1 &&
+		/\b(iPad|Macintosh)\b/.test(navigator.userAgent)
+	);
+}
+
+function shouldUseTouchAutocompleteSurface(isMobile: boolean): boolean {
+	return (
+		isMobile ||
+		matchesMediaQuery('(pointer: coarse)') ||
+		matchesMediaQuery('(hover: none)') ||
+		isDesktopClassIpad()
+	);
+}
+
+function useTouchAutocompleteSurface(isMobile: boolean): boolean {
+	const [shouldUseTouchSurface, setShouldUseTouchSurface] = useState(() =>
+		shouldUseTouchAutocompleteSurface(isMobile)
+	);
+
+	useEffect(() => {
+		const updateTouchSurface = () => {
+			setShouldUseTouchSurface(shouldUseTouchAutocompleteSurface(isMobile));
+		};
+
+		updateTouchSurface();
+
+		if (typeof window === 'undefined' || !window.matchMedia) {
+			return;
+		}
+
+		const mediaQueries = [
+			window.matchMedia('(pointer: coarse)'),
+			window.matchMedia('(hover: none)'),
+		];
+
+		for (const mediaQuery of mediaQueries) {
+			mediaQuery.addEventListener('change', updateTouchSurface);
+		}
+
+		return () => {
+			for (const mediaQuery of mediaQueries) {
+				mediaQuery.removeEventListener('change', updateTouchSurface);
+			}
+		};
+	}, [isMobile]);
+
+	return shouldUseTouchSurface;
+}
+
 export const QuickInput: FC<QuickInputProps> = ({
 	nodeType: initialNodeType,
 	parentNode,
@@ -182,6 +245,7 @@ export const QuickInput: FC<QuickInputProps> = ({
 	onboardingSource,
 }) => {
 	const isMobile = useIsMobile();
+	const usesTouchAutocompleteSurface = useTouchAutocompleteSurface(isMobile);
 
 	// Local UI state
 	const [preview, setPreview] = useState<QuickInputPreview | null>(null);
@@ -284,7 +348,7 @@ export const QuickInput: FC<QuickInputProps> = ({
 		onboardingPatternStep === 'pattern-editor' &&
 		hasSyntaxPatterns;
 	const showMobileCompletionTray =
-		isMobile &&
+		usesTouchAutocompleteSurface &&
 		autocompleteState.status === 'active' &&
 		autocompleteState.options.length > 0;
 
@@ -971,7 +1035,7 @@ export const QuickInput: FC<QuickInputProps> = ({
 							onNodeTypeChange={handleNodeTypeChange}
 							onSelectionChange={handleSelectionChange}
 							placeholder={`Type naturally... ${config.examples?.[0] || ''}`}
-							showNativeAutocomplete={!isMobile}
+							showNativeAutocomplete={!usesTouchAutocompleteSurface}
 							value={value}
 						/>
 

--- a/src/components/node-editor/components/inputs/quick-input.tsx
+++ b/src/components/node-editor/components/inputs/quick-input.tsx
@@ -154,10 +154,7 @@ function sanitizeMentionableUsers(users: unknown[]): MentionableUser[] {
 }
 
 // Helper function to determine if we should auto-process node type switch
-const shouldAutoProcessSwitch = (
-	text: string,
-	currentNodeType?: string
-): boolean => {
+const shouldAutoProcessSwitch = (text: string): boolean => {
 	// Check if text contains a node type trigger (e.g., $task, $note) anywhere
 	// Pattern matches $command followed by space or end of string
 	const nodeTypeTriggerPattern = /\$(\w+)(\s|$)/;
@@ -571,7 +568,7 @@ export const QuickInput: FC<QuickInputProps> = ({
 
 		// Only use legacy processing if commands are disabled or as fallback
 		// The primary processing should happen via CodeMirror events
-		if (shouldAutoProcessSwitch(value, currentNodeType)) {
+		if (shouldAutoProcessSwitch(value)) {
 			const processed = processNodeTypeSwitch(value);
 
 			if (
@@ -957,10 +954,10 @@ export const QuickInput: FC<QuickInputProps> = ({
 		>
 			<Tabs
 				className='flex h-full min-h-0 flex-col gap-0'
+				value={rightPanelTab}
 				onValueChange={(nextValue) =>
 					setRightPanelTab(nextValue as RightPanelTab)
 				}
-				value={rightPanelTab}
 			>
 				<div
 					className='grid shrink-0 grid-cols-1 sm:grid-cols-[minmax(0,1fr)_1px_minmax(0,1fr)]'
@@ -1087,14 +1084,14 @@ export const QuickInput: FC<QuickInputProps> = ({
 									nodeSpecificPatterns={nodeSpecificPatterns}
 									onPatternClick={handlePatternInsert}
 									onToggleCollapse={handleLegendCollapseToggle}
+									universalPatterns={universalPatterns}
+									variant='panel'
 									onToggleNodeSpecificCollapse={
 										handleNodeSpecificLegendCollapseToggle
 									}
 									onToggleUniversalCollapse={
 										handleUniversalLegendCollapseToggle
 									}
-									universalPatterns={universalPatterns}
-									variant='panel'
 								/>
 							) : (
 								<div className='rounded-sm bg-zinc-950/20 p-4 text-xs leading-5 text-zinc-500'>
@@ -1132,6 +1129,7 @@ export const QuickInput: FC<QuickInputProps> = ({
 							className='mx-4 mb-3 flex shrink-0 items-center gap-2 rounded-sm bg-amber-500/10 p-3 text-amber-400'
 						>
 							<AlertCircle className='w-4 h-4 shrink-0' />
+
 							<span className='text-sm'>
 								{nodeLimitMessage ||
 									(nodeLimitInfo
@@ -1143,16 +1141,16 @@ export const QuickInput: FC<QuickInputProps> = ({
 
 				<div className='shrink-0' data-testid='quick-input-footer-row'>
 					<ActionBar
-						canCreate={
-							value.trim().length > 0 &&
-							(!isCreateMode ||
-								(!isCreateBlockedByNodeLimit && !isCreateLimitCheckLoading))
-						}
 						className='mt-0 border-t border-zinc-800/80 px-4 py-3'
 						isCreating={isCreating}
 						isCheckingLimit={isCreateLimitCheckLoading}
 						mode={mode}
 						onCreate={handleCreate}
+						canCreate={
+							value.trim().length > 0 &&
+							(!isCreateMode ||
+								(!isCreateBlockedByNodeLimit && !isCreateLimitCheckLoading))
+						}
 					/>
 				</div>
 			</Tabs>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved autocomplete tray on iPad/tablet touch environments so the React tray is used consistently while preserving keyboard selection behavior.

* **Documentation**
  * Updated docs and changelog to describe touch-first autocomplete behavior and import requirements for the ESLint flat-config.

* **Tests**
  * Added responsive autocomplete tests to cover touch/desktop-class iPad behavior.

* **Chores**
  * Updated ESLint flat-config setup to import Next presets directly and pin React version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kudziajaroslaw98/moistus-ai/pull/62)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->